### PR TITLE
feat: add Google Analytics component and include in Layout

### DIFF
--- a/src/components/GoogleAnalytics.astro
+++ b/src/components/GoogleAnalytics.astro
@@ -1,0 +1,15 @@
+---
+const GA_ID = import.meta.env.PUBLIC_GA_ID ?? 'G-1X5E9W6VJ2';
+---
+{GA_ID && (
+  <>
+    <!-- Google tag (gtag.js) -->
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
+    <script>
+      {`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${GA_ID}');`}
+    </script>
+  </>
+)}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import { LOCALE, SITE } from "@config";
 import "@styles/base.css";
 import { ViewTransitions } from "astro:transitions";
+import GoogleAnalytics from "@components/GoogleAnalytics.astro";
 
 const googleSiteVerification = import.meta.env.PUBLIC_GOOGLE_SITE_VERIFICATION;
 
@@ -35,7 +36,7 @@ const socialImageURL = new URL(
 
 <!doctype html>
 <html
-  lang=`${LOCALE.lang ?? "en"}`
+  lang={`${LOCALE.lang ?? "en"}`}
   class={`${scrollSmooth && "scroll-smooth"}`}
 >
   <head>
@@ -104,6 +105,9 @@ const socialImageURL = new URL(
         />
       )
     }
+
+    <!-- Google Analytics (gtag) -->
+    <GoogleAnalytics />
 
     <ViewTransitions />
 


### PR DESCRIPTION
Adds src/components/GoogleAnalytics.astro which loads gtag.js and initializes with the PUBLIC_GA_ID env var (falls back to G-1X5E9W6VJ2).
Imports and includes the component in src/layouts/Layout.astro so analytics run site-wide.
To use a custom GA ID set PUBLIC_GA_ID in your environment. Consider adding anonymize_ip or consent gating if required by your privacy policy.