### PR TITLE
feat(comments): switch annotations to D1 primary

### DIFF
--- a/docs/cloudflare-first-migration-handoff.md
+++ b/docs/cloudflare-first-migration-handoff.md
@@ -1,40 +1,45 @@
 # Cloudflare Migration Agent Handoff
 
-Status: Phase 4 complete; shadow-write observation active
+Status: Phase 5 implemented; production D1 observation active
 
 Last verified: 2026-08-04 (Asia/Shanghai)
 
 Repository: `llccing/llccing.github.io`
 
-Branch: `codex/cloudflare-pages-phase-4`
+Branch: `codex/cloudflare-pages-phase-5`
 
-Base: `main` at `2ed4469f`
+Base: `main` at `005d5930`
 
 ## Objective
 
-Continue the Cloudflare-first migration one phase at a time. Preserve GitHub
-source, Discussions, Giscus, Pages rollback infrastructure, the legacy Worker
-URL, Chinese locale behavior, and Asia/Shanghai publishing assumptions.
+Continue the Cloudflare-first migration one authorized phase at a time.
+Preserve GitHub source, Discussions, Giscus, GitHub Pages rollback
+infrastructure, the Worker fallback URL, Chinese locale behavior, and
+Asia/Shanghai publishing assumptions.
 
-Detailed Phase 4 evidence is in
-`docs/cloudflare-first-migration-phase-4-report.md`.
+Detailed evidence is in
+`docs/cloudflare-first-migration-phase-5-report.md`.
 
 ## Current Production State
 
 - `rowanliu.com` and `www.rowanliu.com` are served by Cloudflare Pages.
 - Cloudflare is registrar and authoritative DNS provider.
-- The custom-domain Worker routes are `rowanliu.com/api/*` and
-  `rowanliu.com/auth/*`.
+- Worker routes are `rowanliu.com/api/*` and `rowanliu.com/auth/*`.
 - Worker `rowan-blog-comments` version
-  `9b4b990d-9c60-492a-924b-2dcf17baea92` is deployed.
+  `4629153e-768f-4812-b25a-1fa43cbefcce` is deployed.
 - `https://rowan-blog-comments.lcf33123.workers.dev` remains enabled.
 - D1 `rowan-blog-annotations`
-  (`af86d172-7c99-4bb1-8512-80175a1bcbb7`, APAC) has migration
-  `0001_annotations_shadow.sql` applied.
-- Remote D1 contains 1 article, 3 annotations, and 2 replies with zero
-  reconciliation mismatches.
-- GitHub Discussions remains authoritative for all public reads and mutations.
-- Successful GitHub mutations now schedule non-blocking D1 shadow writes.
+  (`af86d172-7c99-4bb1-8512-80175a1bcbb7`, APAC) has migrations `0001` and
+  `0002` applied.
+- Remote D1 contains 1 article, 3 annotations, and 2 replies. All imported
+  records have `github_mirror_state = 'synced'`; foreign-key checks are clean.
+- D1 is authoritative for annotation reads and writes.
+- GitHub mirroring runs asynchronously with `ctx.waitUntil()` and cannot turn a
+  successful D1 mutation into an HTTP failure.
+- Public responses carry an article version and ETag. Matching
+  `If-None-Match` requests return `304`.
+- The frontend applies optimistic create, reply, edit, and delete state and
+  does not reload the complete list after a mutation.
 
 ## Preserved Rollback Paths
 
@@ -42,65 +47,61 @@ Detailed Phase 4 evidence is in
 - Keep `.github/workflows/annotation-ai.yml` active until Phase 6 has passed its
   observation period.
 - Keep `.github/workflows/deploy.yml` and `origin/gh-pages`.
-- Keep the current Pages production deployment and `workers.dev` fallback.
-- Do not delete D1 on rollback; it is not required by public reads in Phase 4.
-- Previous Worker version:
-  `e443de6c-06e9-4bfb-9edb-91c9b6fcb474`.
+- Keep the last verified Cloudflare Pages deployment and `workers.dev`
+  fallback.
+- Do not delete D1 on rollback. Preserve the pre-migration SQL export under the
+  ignored `artifacts/cloudflare-migration/` directory.
+- Phase 4 Worker rollback version:
+  `9b4b990d-9c60-492a-924b-2dcf17baea92`.
 
-## Phase 4 Observation
+## Phase 5 Observation
 
-No synthetic production mutation was made for the Phase 4 release. After the
-owner next creates, edits, replies to, or deletes an annotation normally, run:
+Structured Worker metrics use message `comments_d1_metric` and record route,
+operation, HTTP status, D1 duration, result count, and article version. They do
+not contain bodies, cookies, CSRF values, prompts, or secrets.
 
-```powershell
-pnpm comments:d1:reconcile -- `
-  --input artifacts/cloudflare-migration/annotations-2026-08-03.json `
-  --remote
-```
+GitHub archive failures use message `github_mirror_failed`. New records retain
+an internal pending mirror identifier until GitHub returns a real node ID.
+Existing real node IDs remain available for a later retry if an update mirror
+fails.
 
-The static backup will intentionally report differences after a legitimate new
-mutation. Export a fresh GitHub snapshot and reconcile against that snapshot to
-prove current shadow parity. Never run import merely to hide a mismatch; first
-classify whether it is a legitimate GitHub change or a D1 shadow failure.
+Monitor a representative production sample before reporting a true p95. The
+release verification contains only a small set of end-to-end samples and must
+not be presented as a statistically meaningful D1 p95.
 
-Structured Worker failures use message `d1_shadow_write_failed` and include the
-operation, resource ID, and article path without secrets.
+## Next Phase
 
-## Next Phases
+Phase 6 directly addresses slow `@AI` replies. It should:
 
-Phase 5 makes D1 authoritative for reads and writes, adds optimistic frontend
-updates, versioned responses, conditional refetch, soft deletion, revision
-history, and latency/error metrics. It removes GitHub GraphQL and full-list
-reload latency from normal annotation CRUD.
+1. Enqueue owner annotations containing `@ai`.
+2. Process jobs with an idempotent Cloudflare Queue consumer.
+3. Write AI replies to D1.
+4. Expose queued, answering, completed, failed, and retry states.
+5. Benchmark the selected model before changing providers.
 
-Phase 6 directly addresses slow `@AI` replies. It enqueues owner annotations
-containing `@ai`, processes them in an idempotent Cloudflare Queue consumer,
-writes replies to D1, and exposes queued/answering/completed/failed/retry UI
-states. GitHub Actions remains active until the Queue path has been observed and
-the old workflow is explicitly disabled.
-
-Do not start Phase 5, Phase 6, Queues, Durable Objects, public D1 reads, workflow
-retirement, or DNS changes without explicit authorization for that phase.
+Do not disable `.github/workflows/annotation-ai.yml` until the Queue path has
+passed its observation period. Do not add Durable Objects, WebSockets, DNS
+changes, Giscus changes, Discussion deletion, or GitHub Pages retirement as
+part of Phase 6.
 
 ## Validation Baseline
 
 - `pnpm lint`: passed
-- `pnpm test`: 6 files, 32 tests passed
+- `pnpm test`: 7 files, 34 tests passed
 - `pnpm check:worker`: passed
 - Production `pnpm build`: passed
 - Astro Check: 0 errors, 0 warnings, 0 hints
-- Jampack: 720 files, 36.57 MiB to 28.75 MiB
+- Jampack: 721 files, 36.59 MiB to 28.77 MiB
 - Targeted Prettier: passed
 - `git diff --check`: passed
-- Same-origin and fallback reads: HTTP 200
-- Anonymous session: read-only
-- Anonymous mutation: HTTP 401
-- Final D1 reconciliation: 1/3/2, zero mismatches
+- Remote migration: 1/3/2 rows, all imported mirrors synced
+- Same-origin D1 read: HTTP 200, 3 annotations, 2 replies
+- Conditional read: HTTP 304 with `ETag: "comments-0"`
 
 ## Resume Checklist
 
-1. Read `AGENTS.md`, this handoff, the migration plan, and the Phase 4 report.
-2. Inspect `git status`, the current branch, and live Worker/Pages versions.
-3. Preserve unrelated dirty-worktree changes.
-4. Observe at least one normal owner mutation and reconcile a fresh export.
-5. Obtain explicit authorization before starting Phase 5.
+1. Read `AGENTS.md`, this handoff, the migration plan, and the Phase 5 report.
+2. Inspect `git status`, the active branch, and live Worker/Pages versions.
+3. Check recent `comments_d1_metric` and `github_mirror_failed` logs.
+4. Preserve all rollback infrastructure and ignored backup artifacts.
+5. Obtain explicit authorization before starting Phase 6.

--- a/docs/cloudflare-first-migration-phase-5-report.md
+++ b/docs/cloudflare-first-migration-phase-5-report.md
@@ -1,0 +1,161 @@
+# Cloudflare Migration Phase 5 Report
+
+Date: 2026-08-04 (Asia/Shanghai)
+
+Status: Phase 5 implemented; production observation active
+
+Production domain: `https://rowanliu.com`
+
+## Scope
+
+Phase 5 makes D1 authoritative for annotation reads and writes, removes GitHub
+GraphQL and complete-list reloads from normal CRUD latency, adds optimistic UI
+state, versioned conditional reads, revision history, soft deletion, and
+structured D1 metrics.
+
+This phase does not replace the slow GitHub Actions `@AI` workflow. Queue-based
+AI processing is Phase 6. It also does not add Durable Objects or WebSockets,
+change DNS or Giscus, delete Discussions, disable workflows, or remove GitHub
+Pages rollback infrastructure.
+
+## Data Protection And Migration
+
+A fresh GitHub Discussions export was reconciled before implementation:
+
+| Record | GitHub export | Remote D1 |
+| --- | ---: | ---: |
+| Articles | 1 | 1 |
+| Annotations | 3 | 3 |
+| Replies | 2 | 2 |
+| Mismatches | 0 | 0 |
+
+Ignored baseline:
+`artifacts/cloudflare-migration/annotations-phase5-baseline-2026-08-04.json`.
+
+Before the remote migration, the complete D1 database was exported to the
+ignored file
+`artifacts/cloudflare-migration/d1-phase5-pre-migration-2026-08-04.sql`.
+
+Migration `0002_d1_primary.sql` adds `github_mirror_state` to articles,
+annotations, and replies. Existing imported records default to `synced`. New
+D1-first records use unique pending GitHub identifiers until the asynchronous
+archive returns real GitHub node IDs and URLs. This avoids rebuilding populated
+tables or weakening the Phase 4 uniqueness constraints.
+
+The migration was applied locally before remote. Both environments retained
+1 article, 3 annotations, and 2 replies, and both returned an empty
+`PRAGMA foreign_key_check` result.
+
+## Authoritative D1 API
+
+`GET /api/comments` now reads articles, active annotations, and active replies
+directly through the D1 binding. It does not call GitHub. Queries use prepared
+statements and exclude annotations with `status != 'open'`, annotations with a
+`deleted_at` value, their child replies, and individually deleted replies.
+
+Responses include the article `version` and an ETag of
+`"comments-<version>"`. A matching `If-None-Match` returns `304` without a
+response body.
+
+Authenticated mutations now use this order:
+
+1. Validate origin, owner session, CSRF token, path, and request body.
+2. Create, update, or soft-delete the D1 resource.
+3. Increment the article version exactly once.
+4. Return the D1 result to the browser.
+5. Mirror to GitHub asynchronously with `ctx.waitUntil()`.
+
+Edits insert the previous body into `annotation_revisions`. Annotation deletion
+soft-deletes its child replies. A GitHub archive failure changes mirror state
+and emits a structured error, but cannot convert a successful D1 operation into
+an HTTP error.
+
+## Optimistic Frontend
+
+The existing React annotation island now updates local state before awaiting
+the network:
+
+- annotation create inserts a temporary thread;
+- reply create appends a temporary reply;
+- edit updates the displayed body;
+- delete removes the resource immediately;
+- success replaces temporary IDs with authoritative D1 IDs;
+- failure restores the exact previous snapshot and exposes a retry action.
+
+Pending state uses fixed-size spinner slots and restrained opacity. Mutations
+are serialized so one rollback cannot overwrite a concurrent successful
+operation. Mutation handlers no longer call the complete-list `reload()`.
+
+## Observability
+
+Structured `comments_d1_metric` logs include route, operation, HTTP status, D1
+duration, result count where relevant, and article version. Failure logs contain
+operation, resource ID, article path, and error class/message only. Bodies,
+cookies, CSRF tokens, prompts, OAuth values, and secrets are excluded.
+
+Eight small end-to-end production read samples from the release machine ranged
+from 422 ms to 750 ms. Those measurements include client network and TLS time
+and are not a valid D1 p95. Cloudflare-reported migration verification queries
+were below 1 ms, but those are administrative SQL timings rather than public
+request latency. A true production p95 requires an observation window with
+enough `comments_d1_metric` events.
+
+## Deployment
+
+- D1 migration: `0002_d1_primary.sql`
+- Previous Worker version: `9b4b990d-9c60-492a-924b-2dcf17baea92`
+- Phase 5 Worker version: `4629153e-768f-4812-b25a-1fa43cbefcce`
+- Worker startup time: 13 ms
+- Same-origin routes: `rowanliu.com/api/*` and `rowanliu.com/auth/*`
+- Fallback: `https://rowan-blog-comments.lcf33123.workers.dev`
+
+The Worker was deployed before the frontend. The additive `version` field and
+new mutation responses remain compatible with the Phase 4 frontend during the
+staged rollout.
+
+## Production Evidence
+
+| Check | Result |
+| --- | --- |
+| Same-origin `GET /api/comments` | 200, D1-backed, 3 annotations and 2 replies |
+| Conditional read | 304, empty body, `ETag: "comments-0"` |
+| Remote D1 counts | 1 article, 3 annotations, 2 replies |
+| Imported mirror states | all `synced` |
+| Remote foreign-key check | no violations |
+| Public-read GitHub calls in test | zero |
+| Async GitHub failure containment | D1 success retained; failure logged |
+
+## Validation
+
+| Check | Result |
+| --- | --- |
+| `pnpm lint` | Passed |
+| `pnpm test` | Passed: 7 files, 34 tests |
+| `pnpm check:worker` | Passed |
+| Production `pnpm build` | Passed |
+| Astro Check | 0 errors, 0 warnings, 0 hints |
+| Jampack | 721 files, 36.59 MiB to 28.77 MiB |
+| Targeted Prettier | Passed |
+| `git diff --check` | Passed |
+
+## Rollback
+
+- Roll the Worker back to
+  `9b4b990d-9c60-492a-924b-2dcf17baea92` if D1-primary behavior fails.
+- Restore the last verified Cloudflare Pages deployment if optimistic UI
+  behavior fails.
+- Keep D1 and its SQL backup for investigation; do not drop tables or erase
+  Phase 5 writes during rollback.
+- GitHub Discussions, Giscus, `workers.dev`, `origin/gh-pages`,
+  `.github/workflows/deploy.yml`, and `.github/workflows/annotation-ai.yml`
+  remain intact.
+
+## Outcome And Next Boundary
+
+Phase 5 removes GitHub GraphQL and full-list reloads from normal annotation
+CRUD. Phase 6 is the next authorized boundary and directly addresses slow
+`@AI` replies with Cloudflare Queues, idempotent job processing, D1 reply writes,
+and visible retry state.
+
+Do not start Phase 6 or disable the GitHub Actions AI workflow until Phase 5
+observation is accepted and Phase 6 is explicitly authorized.

--- a/docs/cloudflare-first-migration-plan.md
+++ b/docs/cloudflare-first-migration-plan.md
@@ -507,11 +507,16 @@ Exit criteria:
 
 ### Phase 5: D1 primary read/write switch
 
+Implementation status: completed on 2026-08-04. Production observation and
+the Phase 6 authorization boundary remain active.
+
 Tasks:
 
 - Switch reads to D1.
 - Switch writes to D1 and use optimistic client updates.
-- Move GitHub mirroring behind a Queue or disable it after an explicit decision.
+- Move GitHub mirroring off the synchronous request path with
+  `ExecutionContext.waitUntil()`. Queue-backed durability is deferred to the
+  explicitly separate Phase 6.
 - Add versioned responses, conditional refetch, soft delete, and revision
   history.
 - Add latency and error metrics.

--- a/migrations/comments-api/0002_d1_primary.sql
+++ b/migrations/comments-api/0002_d1_primary.sql
@@ -1,0 +1,17 @@
+ALTER TABLE articles
+  ADD COLUMN github_mirror_state TEXT NOT NULL DEFAULT 'synced'
+  CHECK (github_mirror_state IN ('pending', 'synced', 'failed'));
+
+ALTER TABLE annotations
+  ADD COLUMN github_mirror_state TEXT NOT NULL DEFAULT 'synced'
+  CHECK (github_mirror_state IN ('pending', 'synced', 'failed'));
+
+ALTER TABLE replies
+  ADD COLUMN github_mirror_state TEXT NOT NULL DEFAULT 'synced'
+  CHECK (github_mirror_state IN ('pending', 'synced', 'failed'));
+
+CREATE INDEX annotations_github_mirror_state_idx
+  ON annotations(github_mirror_state, updated_at);
+
+CREATE INDEX replies_github_mirror_state_idx
+  ON replies(github_mirror_state, updated_at);

--- a/src/comments/optimistic.test.ts
+++ b/src/comments/optimistic.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { AnnotationThread } from "./protocol";
+import {
+  removeOptimisticResource,
+  replaceOptimisticReply,
+  replaceOptimisticThread,
+  updateOptimisticBody,
+} from "./optimistic";
+
+const thread: AnnotationThread = {
+  id: "thread-1",
+  url: "",
+  bodyHtml: "",
+  bodyText: "before",
+  createdAt: "2026-08-04T00:00:00Z",
+  updatedAt: "2026-08-04T00:00:00Z",
+  author: { login: "llccing", avatarUrl: "", url: "" },
+  anchor: {
+    blockId: "block",
+    headingId: null,
+    exact: "text",
+    prefix: "",
+    suffix: "",
+    view: "article",
+  },
+  replies: [
+    {
+      id: "reply-1",
+      bodyHtml: "",
+      bodyText: "reply before",
+      createdAt: "2026-08-04T00:00:00Z",
+      updatedAt: "2026-08-04T00:00:00Z",
+      author: { login: "llccing", avatarUrl: "", url: "" },
+    },
+  ],
+};
+
+describe("optimistic comment state", () => {
+  it("replaces temporary annotations and replies with saved resources", () => {
+    expect(
+      replaceOptimisticThread([{ ...thread, id: "temp" }], "temp", thread)[0].id
+    ).toBe("thread-1");
+    const reply = {
+      ...thread.replies[0],
+      id: "saved",
+      annotationId: thread.id,
+    };
+    expect(
+      replaceOptimisticReply(
+        [{ ...thread, replies: [{ ...thread.replies[0], id: "temp" }] }],
+        "temp",
+        reply
+      )[0].replies[0].id
+    ).toBe("saved");
+  });
+
+  it("updates either resource kind and removes a thread or individual reply", () => {
+    expect(updateOptimisticBody([thread], thread.id, "after")[0].bodyText).toBe(
+      "after"
+    );
+    expect(
+      updateOptimisticBody([thread], "reply-1", "reply after")[0].replies[0]
+        .bodyText
+    ).toBe("reply after");
+    expect(removeOptimisticResource([thread], "reply-1")[0].replies).toEqual(
+      []
+    );
+    expect(removeOptimisticResource([thread], thread.id)).toEqual([]);
+  });
+});

--- a/src/comments/optimistic.ts
+++ b/src/comments/optimistic.ts
@@ -1,0 +1,54 @@
+import type { AnnotationThread, CommentReply } from "./protocol";
+
+export function replaceOptimisticThread(
+  threads: AnnotationThread[],
+  temporaryId: string,
+  saved: AnnotationThread
+): AnnotationThread[] {
+  return threads.map(thread => (thread.id === temporaryId ? saved : thread));
+}
+
+export function replaceOptimisticReply(
+  threads: AnnotationThread[],
+  temporaryId: string,
+  saved: CommentReply & { annotationId: string }
+): AnnotationThread[] {
+  return threads.map(thread =>
+    thread.id === saved.annotationId
+      ? {
+          ...thread,
+          replies: thread.replies.map(reply =>
+            reply.id === temporaryId ? saved : reply
+          ),
+        }
+      : thread
+  );
+}
+
+export function updateOptimisticBody(
+  threads: AnnotationThread[],
+  id: string,
+  body: string
+): AnnotationThread[] {
+  return threads.map(thread => {
+    if (thread.id === id) return { ...thread, bodyText: body };
+    return {
+      ...thread,
+      replies: thread.replies.map(reply =>
+        reply.id === id ? { ...reply, bodyText: body } : reply
+      ),
+    };
+  });
+}
+
+export function removeOptimisticResource(
+  threads: AnnotationThread[],
+  id: string
+): AnnotationThread[] {
+  return threads
+    .filter(thread => thread.id !== id)
+    .map(thread => ({
+      ...thread,
+      replies: thread.replies.filter(reply => reply.id !== id),
+    }));
+}

--- a/src/comments/protocol.ts
+++ b/src/comments/protocol.ts
@@ -53,6 +53,7 @@ export type AnnotationThread = {
 };
 
 export type CommentListResponse = {
+  version: number;
   discussion: null | {
     id: string;
     number: number;
@@ -61,6 +62,12 @@ export type CommentListResponse = {
   };
   threads: AnnotationThread[];
   truncated: boolean;
+};
+
+export type CommentMutationResponse = {
+  version: number;
+  thread?: AnnotationThread;
+  reply?: CommentReply & { annotationId: string };
 };
 
 export type CreateCommentInput = {

--- a/src/components/InlineComments.tsx
+++ b/src/components/InlineComments.tsx
@@ -7,6 +7,7 @@ import {
   MessageSquarePlus,
   Pencil,
   Reply,
+  RotateCcw,
   Send,
   Trash2,
   X,
@@ -17,9 +18,16 @@ import {
   type AnnotationAnchor,
   type AnnotationThread,
   type CommentListResponse,
+  type CommentMutationResponse,
   type CommentView,
 } from "../comments/protocol";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  removeOptimisticResource,
+  replaceOptimisticReply,
+  replaceOptimisticThread,
+  updateOptimisticBody,
+} from "../comments/optimistic";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const ANNOTATION_MODE_KEY = "rowan-comments-annotation-mode";
 const BLOCK_SELECTOR = "[data-comment-block-id]";
@@ -150,6 +158,9 @@ export default function InlineComments({
     return deepLink || localStorage.getItem(ANNOTATION_MODE_KEY) === "true";
   });
   const [threads, setThreads] = useState<AnnotationThread[]>([]);
+  const versionRef = useRef(0);
+  const [syncStates, setSyncStates] = useState<Record<string, "pending">>({});
+  const [retryAction, setRetryAction] = useState<null | (() => void)>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [ownerSession, setOwnerSession] = useState<OwnerSession | null>(null);
@@ -196,16 +207,25 @@ export default function InlineComments({
   const reload = useCallback(async () => {
     try {
       setError("");
-      const data = await request<CommentListResponse>(
-        `/api/comments?path=${encodeURIComponent(articlePath)}`
+      const headers = new Headers();
+      if (versionRef.current > 0) {
+        headers.set("If-None-Match", `"comments-${versionRef.current}"`);
+      }
+      const response = await fetch(
+        `${endpoint}/api/comments?path=${encodeURIComponent(articlePath)}`,
+        { credentials: "include", headers }
       );
+      if (response.status === 304) return;
+      if (!response.ok) throw new Error(`请求失败 (${response.status})`);
+      const data = (await response.json()) as CommentListResponse;
+      versionRef.current = data.version;
       setThreads(data.threads);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "批注加载失败");
     } finally {
       setLoading(false);
     }
-  }, [articlePath, request]);
+  }, [articlePath, endpoint]);
 
   useEffect(() => {
     void reload();
@@ -384,58 +404,149 @@ export default function InlineComments({
       setSelectedKey(`${next.anchor.view}:${next.anchor.blockId}`);
   }
 
-  async function saveComment() {
-    if (!composer || !body.trim()) return;
+  async function performSave(next: ComposerState, text: string) {
+    const previous = threads;
+    const temporaryId = `pending-${crypto.randomUUID()}`;
+    const now = new Date().toISOString();
+    const localAuthor = {
+      login: ownerSession?.login ?? "llccing",
+      avatarUrl: `https://github.com/${ownerSession?.login ?? "llccing"}.png`,
+      url: `https://github.com/${ownerSession?.login ?? "llccing"}`,
+    };
     setSaving(true);
     setError("");
+    setRetryAction(null);
+    setSyncStates(states => ({ ...states, [temporaryId]: "pending" }));
+    if (next.editId) {
+      setSyncStates(states => ({ ...states, [next.editId!]: "pending" }));
+      setThreads(current => updateOptimisticBody(current, next.editId!, text));
+    } else if (next.replyToId) {
+      setThreads(current =>
+        current.map(thread =>
+          thread.id === next.replyToId
+            ? {
+                ...thread,
+                replies: [
+                  ...thread.replies,
+                  {
+                    id: temporaryId,
+                    bodyHtml: "",
+                    bodyText: text,
+                    createdAt: now,
+                    updatedAt: now,
+                    author: localAuthor,
+                  },
+                ],
+              }
+            : thread
+        )
+      );
+    } else if (next.anchor) {
+      setThreads(current => [
+        ...current,
+        {
+          id: temporaryId,
+          url: "",
+          bodyHtml: "",
+          bodyText: text,
+          createdAt: now,
+          updatedAt: now,
+          author: localAuthor,
+          anchor: next.anchor!,
+          replies: [],
+        },
+      ]);
+    }
+    setComposer(null);
+    setBody("");
+    setSelectionAnchor(null);
+    window.getSelection()?.removeAllRanges();
     try {
-      if (composer.editId) {
-        await request(
-          `/api/owner/comments/${encodeURIComponent(composer.editId)}`,
+      if (next.editId) {
+        const result = await request<CommentMutationResponse>(
+          `/api/owner/comments/${encodeURIComponent(next.editId)}`,
           {
             method: "PATCH",
-            body: JSON.stringify({ body }),
+            body: JSON.stringify({ body: text }),
           }
         );
+        versionRef.current = result.version;
       } else {
-        await request("/api/owner/comments", {
-          method: "POST",
-          body: JSON.stringify({
-            path: articlePath,
-            articleTitle,
-            body,
-            anchor: composer.anchor,
-            replyToId: composer.replyToId,
-          }),
-        });
+        const result = await request<CommentMutationResponse>(
+          "/api/owner/comments",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              path: articlePath,
+              articleTitle,
+              body: text,
+              anchor: next.anchor,
+              replyToId: next.replyToId,
+            }),
+          }
+        );
+        versionRef.current = result.version;
+        if (result.thread) {
+          setThreads(current =>
+            replaceOptimisticThread(current, temporaryId, result.thread!)
+          );
+        } else if (result.reply) {
+          setThreads(current =>
+            replaceOptimisticReply(current, temporaryId, result.reply!)
+          );
+        }
       }
-      setComposer(null);
-      setBody("");
-      setSelectionAnchor(null);
-      window.getSelection()?.removeAllRanges();
-      await reload();
     } catch (cause) {
+      setThreads(previous);
       setError(cause instanceof Error ? cause.message : "保存失败");
+      setRetryAction(() => () => void performSave(next, text));
     } finally {
+      setSyncStates(states => {
+        const nextStates = { ...states };
+        delete nextStates[temporaryId];
+        if (next.editId) delete nextStates[next.editId];
+        return nextStates;
+      });
       setSaving(false);
     }
   }
 
-  async function deleteComment(id: string) {
-    if (confirmDeleteId !== id) {
+  async function saveComment() {
+    if (saving || !composer || !body.trim()) return;
+    await performSave(composer, body.trim());
+  }
+
+  async function deleteComment(id: string, confirmed = false) {
+    if (saving) return;
+    if (!confirmed && confirmDeleteId !== id) {
       setConfirmDeleteId(id);
       return;
     }
+    const previous = threads;
+    setThreads(current => removeOptimisticResource(current, id));
+    setSyncStates(states => ({ ...states, [id]: "pending" }));
     setSaving(true);
+    setError("");
+    setRetryAction(null);
     try {
-      await request(`/api/owner/comments/${encodeURIComponent(id)}`, {
-        method: "DELETE",
-      });
+      const result = await request<CommentMutationResponse>(
+        `/api/owner/comments/${encodeURIComponent(id)}`,
+        {
+          method: "DELETE",
+        }
+      );
+      versionRef.current = result.version;
       setConfirmDeleteId(null);
-      await reload();
     } catch (cause) {
+      setThreads(previous);
       setError(cause instanceof Error ? cause.message : "删除失败");
+      setRetryAction(() => () => void deleteComment(id, true));
     } finally {
+      setSyncStates(states => {
+        const nextStates = { ...states };
+        delete nextStates[id];
+        return nextStates;
+      });
       setSaving(false);
     }
   }
@@ -576,9 +687,21 @@ export default function InlineComments({
           </div>
 
           {error && (
-            <p className="mb-3 border-l-2 border-red-600 pl-3 text-sm text-red-600">
-              {error}
-            </p>
+            <div className="mb-3 flex min-h-9 items-center justify-between gap-3 border-l-2 border-red-600 pl-3 text-sm text-red-600">
+              <span>{error}</span>
+              {retryAction && (
+                <button
+                  aria-label="重试"
+                  className="inline-flex h-8 shrink-0 items-center gap-1 rounded px-2 hover:bg-skin-card"
+                  onClick={() => retryAction()}
+                  title="重试"
+                  type="button"
+                >
+                  <RotateCcw aria-hidden="true" size={15} />
+                  重试
+                </button>
+              )}
+            </div>
           )}
           {loading && (
             <Loader2 aria-label="正在加载" className="animate-spin" size={20} />
@@ -586,7 +709,7 @@ export default function InlineComments({
 
           {activeThreads.map(thread => (
             <article
-              className="border-b border-skin-line py-4 first:pt-0"
+              className={`border-b border-skin-line py-4 first:pt-0 ${syncStates[thread.id] ? "opacity-60" : ""}`}
               key={thread.id}
             >
               <blockquote className="mb-3 border-l-2 border-skin-accent pl-3 text-xs opacity-70">
@@ -597,24 +720,39 @@ export default function InlineComments({
                   @{thread.author.login} ·{" "}
                   {new Date(thread.createdAt).toLocaleDateString("zh-CN")}
                 </span>
-                <a
-                  aria-label="在 GitHub 查看"
-                  href={thread.url}
-                  rel="noreferrer"
-                  target="_blank"
-                  title="在 GitHub 查看"
-                >
-                  <ExternalLink aria-hidden="true" size={15} />
-                </a>
+                {syncStates[thread.id] ? (
+                  <Loader2
+                    aria-label="正在保存"
+                    className="animate-spin"
+                    size={15}
+                  />
+                ) : thread.url ? (
+                  <a
+                    aria-label="在 GitHub 查看"
+                    href={thread.url}
+                    rel="noreferrer"
+                    target="_blank"
+                    title="在 GitHub 查看"
+                  >
+                    <ExternalLink aria-hidden="true" size={15} />
+                  </a>
+                ) : null}
               </div>
               <RichText text={extractAnnotationText(thread.bodyText)} />
               {thread.replies.map(reply => (
                 <div
-                  className="ml-4 mt-3 border-l border-skin-line pl-3"
+                  className={`ml-4 mt-3 border-l border-skin-line pl-3 ${syncStates[reply.id] ? "opacity-60" : ""}`}
                   key={reply.id}
                 >
                   <div className="mb-1 text-xs opacity-70">
-                    @{reply.author.login}
+                    <span>@{reply.author.login}</span>
+                    {syncStates[reply.id] && (
+                      <Loader2
+                        aria-label="正在保存"
+                        className="ml-2 inline animate-spin"
+                        size={13}
+                      />
+                    )}
                   </div>
                   <RichText text={readableReply(reply.bodyText)} />
                   {ownerSession &&

--- a/workers/comments-api/src/d1.ts
+++ b/workers/comments-api/src/d1.ts
@@ -1,307 +1,515 @@
-import type { AnnotationMetadata } from "../../../src/comments/protocol";
+import {
+  parseAnnotationMetadata,
+  type AnnotationAnchor,
+  type AnnotationThread,
+  type CommentAuthor,
+  type CommentListResponse,
+  type CommentReply,
+} from "../../../src/comments/protocol";
 
-type GitHubAuthor = {
-  login: string;
-  avatarUrl: string;
-  url: string;
-} | null;
-
-type GitHubCommentRecord = {
+export type D1Resource = {
+  kind: "annotation" | "reply";
   id: string;
-  url: string;
-  createdAt: string;
-  updatedAt: string;
-  author: GitHubAuthor;
-};
-
-type DiscussionRecord = {
-  id: string;
-  number: number;
-  url: string;
-};
-
-type ArticleRecord = {
-  path: string;
-  title: string;
-  discussion: DiscussionRecord;
-};
-
-type ShadowWriteContext = {
-  operation: string;
-  resourceId: string;
   articlePath: string;
+  annotationId: string;
+  body: string;
+  githubNodeId: string | null;
+  githubMirrorState: "pending" | "synced" | "failed";
+  anchor: AnnotationAnchor | null;
 };
+
+type AuthorInput = CommentAuthor;
 
 type CreateAnnotationInput = {
-  article: ArticleRecord;
-  comment: GitHubCommentRecord;
+  path: string;
+  articleTitle: string;
   body: string;
-  metadata: AnnotationMetadata;
+  anchor: AnnotationAnchor;
+  author: AuthorInput;
+  siteUrl: string;
 };
 
 type CreateReplyInput = {
-  article: ArticleRecord;
-  comment: GitHubCommentRecord;
+  path: string;
   annotationId: string;
   body: string;
+  author: AuthorInput;
+  siteUrl: string;
 };
 
-type UpdateAnnotationInput = CreateAnnotationInput;
+type ArticleRow = {
+  path: string;
+  title: string;
+  github_discussion_id: string;
+  github_discussion_number: number;
+  github_url: string;
+  version: number;
+};
 
-type UpdateReplyInput = {
-  article: ArticleRecord;
-  comment: GitHubCommentRecord;
+type AnnotationRow = {
+  id: string;
+  article_path: string;
+  author_login: string;
+  author_avatar_url: string;
+  author_url: string;
   body: string;
+  github_url: string;
+  block_id: string;
+  heading_id: string | null;
+  exact_text: string;
+  prefix_text: string;
+  suffix_text: string;
+  view: AnnotationAnchor["view"];
+  github_node_id: string;
+  github_mirror_state: D1Resource["githubMirrorState"];
+  created_at: string;
+  updated_at: string;
 };
 
-type DeleteResourceInput = {
-  article: ArticleRecord;
-  resourceId: string;
-  deletedAt: string;
+type ReplyRow = {
+  id: string;
+  annotation_id: string;
+  article_path: string;
+  author_login: string;
+  author_avatar_url: string;
+  author_url: string;
+  body: string;
+  github_url: string;
+  github_node_id: string;
+  github_mirror_state: D1Resource["githubMirrorState"];
+  created_at: string;
+  updated_at: string;
 };
 
-const ghostAuthor = {
-  login: "ghost",
-  avatarUrl: "https://github.com/ghost.png",
-  url: "https://github.com/ghost",
-};
+const annotationColumns = `
+  id, article_path, author_login, author_avatar_url, author_url, body,
+  github_url, block_id, heading_id, exact_text, prefix_text, suffix_text,
+  view, github_node_id, github_mirror_state, created_at, updated_at`;
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+const replyColumns = `
+  replies.id, replies.annotation_id, annotations.article_path,
+  replies.author_login, replies.author_avatar_url, replies.author_url,
+  replies.body, replies.github_url, replies.github_node_id,
+  replies.github_mirror_state, replies.created_at, replies.updated_at`;
+
+function pendingValue(id: string): string {
+  return `pending:${id}`;
 }
 
-export function scheduleShadowWrite(
-  ctx: ExecutionContext,
-  details: ShadowWriteContext,
-  operation: () => Promise<void>
-): void {
-  ctx.waitUntil(
-    operation().catch(error => {
-      console.error(
-        JSON.stringify({
-          message: "d1_shadow_write_failed",
-          ...details,
-          error: errorMessage(error),
-        })
-      );
-    })
-  );
+function authorFromRow(row: {
+  author_login: string;
+  author_avatar_url: string;
+  author_url: string;
+}): CommentAuthor {
+  return {
+    login: row.author_login,
+    avatarUrl: row.author_avatar_url,
+    url: row.author_url,
+  };
 }
 
-function upsertArticle(
-  db: D1Database,
-  article: ArticleRecord,
-  timestamp: string
-): D1PreparedStatement {
+function replyFromRow(row: ReplyRow): CommentReply {
+  return {
+    id: row.id,
+    bodyHtml: "",
+    bodyText: row.body,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    author: authorFromRow(row),
+  };
+}
+
+function annotationFromRow(row: AnnotationRow, replies: CommentReply[]): AnnotationThread {
+  return {
+    id: row.id,
+    url: row.github_mirror_state === "synced" ? row.github_url : "",
+    bodyHtml: "",
+    bodyText: row.body,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    author: authorFromRow(row),
+    anchor: {
+      blockId: row.block_id,
+      headingId: row.heading_id,
+      exact: row.exact_text,
+      prefix: row.prefix_text,
+      suffix: row.suffix_text,
+      view: row.view,
+    },
+    replies,
+  };
+}
+
+async function articleVersion(db: D1Database, path: string): Promise<number> {
+  const row = await db
+    .prepare("SELECT version FROM articles WHERE path = ?")
+    .bind(path)
+    .first<{ version: number }>();
+  return row?.version ?? 0;
+}
+
+function incrementVersion(db: D1Database, path: string, timestamp: string): D1PreparedStatement {
   return db
-    .prepare(
-      `INSERT INTO articles (
-        path, title, github_discussion_id, github_discussion_number,
-        github_url, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(path) DO UPDATE SET
-        github_discussion_id = excluded.github_discussion_id,
-        github_discussion_number = excluded.github_discussion_number,
-        github_url = excluded.github_url,
-        updated_at = excluded.updated_at`
-    )
-    .bind(
-      article.path,
-      article.title,
-      article.discussion.id,
-      article.discussion.number,
-      article.discussion.url,
-      timestamp,
-      timestamp
-    );
-}
-
-function incrementVersion(
-  db: D1Database,
-  path: string,
-  timestamp: string
-): D1PreparedStatement {
-  return db
-    .prepare(
-      "UPDATE articles SET version = version + 1, updated_at = ? WHERE path = ?"
-    )
+    .prepare("UPDATE articles SET version = version + 1, updated_at = ? WHERE path = ?")
     .bind(timestamp, path);
 }
 
-function annotationUpsert(
+function insertArticle(
   db: D1Database,
-  input: CreateAnnotationInput
+  path: string,
+  title: string,
+  siteUrl: string,
+  timestamp: string
 ): D1PreparedStatement {
-  const author = input.comment.author ?? ghostAuthor;
+  const placeholder = pendingValue(`discussion:${path}`);
   return db
     .prepare(
-      `INSERT INTO annotations (
-        id, article_path, author_login, author_avatar_url, author_url, body,
-        github_url, block_id, heading_id, exact_text, prefix_text, suffix_text,
-        view, github_node_id, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(id) DO UPDATE SET
-        article_path = excluded.article_path,
-        author_login = excluded.author_login,
-        author_avatar_url = excluded.author_avatar_url,
-        author_url = excluded.author_url,
-        body = excluded.body,
-        github_url = excluded.github_url,
-        block_id = excluded.block_id,
-        heading_id = excluded.heading_id,
-        exact_text = excluded.exact_text,
-        prefix_text = excluded.prefix_text,
-        suffix_text = excluded.suffix_text,
-        view = excluded.view,
-        github_node_id = excluded.github_node_id,
-        updated_at = excluded.updated_at`
+      `INSERT INTO articles (
+        path, title, github_discussion_id, github_discussion_number, github_url,
+        version, created_at, updated_at, github_mirror_state
+      ) VALUES (?, ?, ?, 0, ?, 0, ?, ?, 'pending')
+      ON CONFLICT(path) DO UPDATE SET title = excluded.title, updated_at = excluded.updated_at`
     )
-    .bind(
-      input.comment.id,
-      input.article.path,
-      author.login,
-      author.avatarUrl,
-      author.url,
-      input.body,
-      input.comment.url,
-      input.metadata.anchor.blockId,
-      input.metadata.anchor.headingId,
-      input.metadata.anchor.exact,
-      input.metadata.anchor.prefix,
-      input.metadata.anchor.suffix,
-      input.metadata.anchor.view,
-      input.comment.id,
-      input.comment.createdAt,
-      input.comment.updatedAt
-    );
+    .bind(path, title, placeholder, `${siteUrl}${path}`, timestamp, timestamp);
 }
 
-export async function shadowCreateAnnotation(
+export async function getD1CommentList(
+  db: D1Database,
+  path: string
+): Promise<CommentListResponse> {
+  const article = await db
+    .prepare(
+      `SELECT path, title, github_discussion_id, github_discussion_number,
+        github_url, version FROM articles WHERE path = ?`
+    )
+    .bind(path)
+    .first<ArticleRow>();
+  if (!article) {
+    return { version: 0, discussion: null, threads: [], truncated: false };
+  }
+
+  const [annotationResult, replyResult] = await Promise.all([
+    db
+      .prepare(
+        `SELECT ${annotationColumns} FROM annotations
+        WHERE article_path = ? AND status = 'open' AND deleted_at IS NULL
+        ORDER BY created_at, id`
+      )
+      .bind(path)
+      .all<AnnotationRow>(),
+    db
+      .prepare(
+        `SELECT ${replyColumns} FROM replies
+        JOIN annotations ON annotations.id = replies.annotation_id
+        WHERE annotations.article_path = ? AND annotations.status = 'open'
+          AND annotations.deleted_at IS NULL AND replies.deleted_at IS NULL
+        ORDER BY replies.created_at, replies.id`
+      )
+      .bind(path)
+      .all<ReplyRow>(),
+  ]);
+  const replies = new Map<string, CommentReply[]>();
+  for (const row of replyResult.results) {
+    replies.set(row.annotation_id, [
+      ...(replies.get(row.annotation_id) ?? []),
+      replyFromRow(row),
+    ]);
+  }
+  const discussionIsMirrored = !article.github_discussion_id.startsWith("pending:");
+  return {
+    version: article.version,
+    discussion: discussionIsMirrored
+      ? {
+          id: article.github_discussion_id,
+          number: article.github_discussion_number,
+          title: article.title,
+          url: article.github_url,
+        }
+      : null,
+    threads: annotationResult.results.map(row =>
+      annotationFromRow(row, replies.get(row.id) ?? [])
+    ),
+    truncated: false,
+  };
+}
+
+export async function createD1Annotation(
   db: D1Database,
   input: CreateAnnotationInput
-): Promise<void> {
+): Promise<{ thread: AnnotationThread; version: number }> {
+  const id = crypto.randomUUID();
+  const timestamp = new Date().toISOString();
+  const placeholder = pendingValue(id);
   await db.batch([
-    upsertArticle(db, input.article, input.comment.updatedAt),
-    annotationUpsert(db, input),
-    incrementVersion(db, input.article.path, input.comment.updatedAt),
+    insertArticle(db, input.path, input.articleTitle, input.siteUrl, timestamp),
+    db
+      .prepare(
+        `INSERT INTO annotations (
+          id, article_path, author_login, author_avatar_url, author_url, body,
+          github_url, block_id, heading_id, exact_text, prefix_text, suffix_text,
+          view, status, github_node_id, created_at, updated_at, github_mirror_state
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, 'pending')`
+      )
+      .bind(
+        id,
+        input.path,
+        input.author.login,
+        input.author.avatarUrl,
+        input.author.url,
+        input.body,
+        `${input.siteUrl}${input.path}#annotation-${id}`,
+        input.anchor.blockId,
+        input.anchor.headingId,
+        input.anchor.exact,
+        input.anchor.prefix,
+        input.anchor.suffix,
+        input.anchor.view,
+        placeholder,
+        timestamp,
+        timestamp
+      ),
+    incrementVersion(db, input.path, timestamp),
   ]);
+  return {
+    version: await articleVersion(db, input.path),
+    thread: {
+      id,
+      url: "",
+      bodyHtml: "",
+      bodyText: input.body,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      author: input.author,
+      anchor: input.anchor,
+      replies: [],
+    },
+  };
 }
 
-export async function shadowCreateReply(
+export async function createD1Reply(
   db: D1Database,
   input: CreateReplyInput
-): Promise<void> {
-  const author = input.comment.author ?? ghostAuthor;
+): Promise<{ reply: CommentReply & { annotationId: string }; version: number }> {
+  const parent = await db
+    .prepare(
+      `SELECT id FROM annotations WHERE id = ? AND article_path = ?
+      AND status = 'open' AND deleted_at IS NULL`
+    )
+    .bind(input.annotationId, input.path)
+    .first<{ id: string }>();
+  if (!parent) throw new Error("annotation_not_found");
+  const id = crypto.randomUUID();
+  const timestamp = new Date().toISOString();
   await db.batch([
-    upsertArticle(db, input.article, input.comment.updatedAt),
     db
       .prepare(
         `INSERT INTO replies (
           id, annotation_id, author_login, author_avatar_url, author_url, body,
-          github_url, kind, github_node_id, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'human', ?, ?, ?)
-        ON CONFLICT(id) DO UPDATE SET
-          annotation_id = excluded.annotation_id,
-          author_login = excluded.author_login,
-          author_avatar_url = excluded.author_avatar_url,
-          author_url = excluded.author_url,
-          body = excluded.body,
-          github_url = excluded.github_url,
-          kind = excluded.kind,
-          github_node_id = excluded.github_node_id,
-          updated_at = excluded.updated_at`
+          github_url, kind, github_node_id, created_at, updated_at, github_mirror_state
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'human', ?, ?, ?, 'pending')`
       )
       .bind(
-        input.comment.id,
+        id,
         input.annotationId,
-        author.login,
-        author.avatarUrl,
-        author.url,
+        input.author.login,
+        input.author.avatarUrl,
+        input.author.url,
         input.body,
-        input.comment.url,
-        input.comment.id,
-        input.comment.createdAt,
-        input.comment.updatedAt
+        `${input.siteUrl}${input.path}#reply-${id}`,
+        pendingValue(id),
+        timestamp,
+        timestamp
       ),
-    incrementVersion(db, input.article.path, input.comment.updatedAt),
+    incrementVersion(db, input.path, timestamp),
   ]);
+  return {
+    version: await articleVersion(db, input.path),
+    reply: {
+      id,
+      annotationId: input.annotationId,
+      bodyHtml: "",
+      bodyText: input.body,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      author: input.author,
+    },
+  };
 }
 
-export async function shadowUpdateAnnotation(
+export async function getD1Resource(
   db: D1Database,
-  input: UpdateAnnotationInput
-): Promise<void> {
-  await shadowCreateAnnotation(db, input);
-}
-
-export async function shadowUpdateReply(
-  db: D1Database,
-  input: UpdateReplyInput
-): Promise<void> {
-  await upsertArticle(db, input.article, input.comment.updatedAt).run();
-  const result = await db
+  id: string,
+  ownerLogin: string
+): Promise<D1Resource | null> {
+  const annotation = await db
     .prepare(
-      `UPDATE replies SET
-        body = ?, github_url = ?, updated_at = ?
-      WHERE id = ? AND deleted_at IS NULL`
+      `SELECT ${annotationColumns} FROM annotations
+      WHERE id = ? AND author_login = ? AND status = 'open' AND deleted_at IS NULL`
     )
-    .bind(
-      input.body,
-      input.comment.url,
-      input.comment.updatedAt,
-      input.comment.id
-    )
-    .run();
-  if (result.meta.changes !== 1) {
-    throw new Error(`D1 reply ${input.comment.id} was not found for update`);
+    .bind(id, ownerLogin)
+    .first<AnnotationRow>();
+  if (annotation) {
+    return {
+      kind: "annotation",
+      id,
+      articlePath: annotation.article_path,
+      annotationId: id,
+      body: annotation.body,
+      githubNodeId: annotation.github_node_id.startsWith("pending:")
+        ? null
+        : annotation.github_node_id,
+      githubMirrorState: annotation.github_mirror_state,
+      anchor: {
+        blockId: annotation.block_id,
+        headingId: annotation.heading_id,
+        exact: annotation.exact_text,
+        prefix: annotation.prefix_text,
+        suffix: annotation.suffix_text,
+        view: annotation.view,
+      },
+    };
   }
-  await incrementVersion(
-    db,
-    input.article.path,
-    input.comment.updatedAt
-  ).run();
+  const reply = await db
+    .prepare(
+      `SELECT ${replyColumns} FROM replies
+      JOIN annotations ON annotations.id = replies.annotation_id
+      WHERE replies.id = ? AND replies.author_login = ?
+        AND replies.deleted_at IS NULL AND annotations.deleted_at IS NULL`
+    )
+    .bind(id, ownerLogin)
+    .first<ReplyRow>();
+  return reply
+    ? {
+        kind: "reply",
+        id,
+        articlePath: reply.article_path,
+        annotationId: reply.annotation_id,
+        body: reply.body,
+        githubNodeId: reply.github_node_id.startsWith("pending:")
+          ? null
+          : reply.github_node_id,
+        githubMirrorState: reply.github_mirror_state,
+        anchor: null,
+      }
+    : null;
 }
 
-export async function shadowDeleteAnnotation(
+export async function updateD1Resource(
   db: D1Database,
-  input: DeleteResourceInput
-): Promise<void> {
+  resource: D1Resource,
+  body: string,
+  changedBy: string
+): Promise<{ version: number; updatedAt: string }> {
+  const timestamp = new Date().toISOString();
+  const table = resource.kind === "annotation" ? "annotations" : "replies";
   const results = await db.batch([
-    upsertArticle(db, input.article, input.deletedAt),
     db
       .prepare(
-        `UPDATE annotations SET
-          status = 'deleted', deleted_at = ?, updated_at = ?
-        WHERE id = ? AND deleted_at IS NULL`
+        `INSERT INTO annotation_revisions
+          (resource_type, resource_id, previous_body, changed_at, changed_by)
+        VALUES (?, ?, ?, ?, ?)`
       )
-      .bind(input.deletedAt, input.deletedAt, input.resourceId),
+      .bind(resource.kind, resource.id, resource.body, timestamp, changedBy),
     db
-      .prepare(
-        `UPDATE replies SET deleted_at = ?, updated_at = ?
-        WHERE annotation_id = ? AND deleted_at IS NULL`
-      )
-      .bind(input.deletedAt, input.deletedAt, input.resourceId),
-    incrementVersion(db, input.article.path, input.deletedAt),
+      .prepare(`UPDATE ${table} SET body = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL`)
+      .bind(body, timestamp, resource.id),
+    incrementVersion(db, resource.articlePath, timestamp),
   ]);
-  if (results[1].meta.changes !== 1) {
-    throw new Error(`D1 annotation ${input.resourceId} was not found for delete`);
-  }
+  if (results[1].meta.changes !== 1) throw new Error("resource_not_found");
+  return { version: await articleVersion(db, resource.articlePath), updatedAt: timestamp };
 }
 
-export async function shadowDeleteReply(
+export async function deleteD1Resource(
   db: D1Database,
-  input: DeleteResourceInput
-): Promise<void> {
-  await upsertArticle(db, input.article, input.deletedAt).run();
-  const result = await db
+  resource: D1Resource
+): Promise<{ version: number }> {
+  const timestamp = new Date().toISOString();
+  const statements = resource.kind === "annotation"
+    ? [
+        db
+          .prepare(
+            `UPDATE annotations SET status = 'deleted', deleted_at = ?, updated_at = ?
+            WHERE id = ? AND deleted_at IS NULL`
+          )
+          .bind(timestamp, timestamp, resource.id),
+        db
+          .prepare(
+            `UPDATE replies SET deleted_at = ?, updated_at = ?
+            WHERE annotation_id = ? AND deleted_at IS NULL`
+          )
+          .bind(timestamp, timestamp, resource.id),
+      ]
+    : [
+        db
+          .prepare(
+            `UPDATE replies SET deleted_at = ?, updated_at = ?
+            WHERE id = ? AND deleted_at IS NULL`
+          )
+          .bind(timestamp, timestamp, resource.id),
+      ];
+  const results = await db.batch([
+    ...statements,
+    incrementVersion(db, resource.articlePath, timestamp),
+  ]);
+  if (results[0].meta.changes !== 1) throw new Error("resource_not_found");
+  return { version: await articleVersion(db, resource.articlePath) };
+}
+
+export async function getD1Article(db: D1Database, path: string): Promise<ArticleRow | null> {
+  return db
     .prepare(
-      `UPDATE replies SET deleted_at = ?, updated_at = ?
-      WHERE id = ? AND deleted_at IS NULL`
+      `SELECT path, title, github_discussion_id, github_discussion_number,
+        github_url, version FROM articles WHERE path = ?`
     )
-    .bind(input.deletedAt, input.deletedAt, input.resourceId)
+    .bind(path)
+    .first<ArticleRow>();
+}
+
+export async function markArticleMirrored(
+  db: D1Database,
+  path: string,
+  discussion: { id: string; number: number; url: string }
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE articles SET github_discussion_id = ?, github_discussion_number = ?,
+        github_url = ?, github_mirror_state = 'synced' WHERE path = ?`
+    )
+    .bind(discussion.id, discussion.number, discussion.url, path)
     .run();
-  if (result.meta.changes !== 1) {
-    throw new Error(`D1 reply ${input.resourceId} was not found for delete`);
-  }
-  await incrementVersion(db, input.article.path, input.deletedAt).run();
+}
+
+export async function markResourceMirrored(
+  db: D1Database,
+  resource: D1Resource,
+  github: { id: string; url: string }
+): Promise<void> {
+  const table = resource.kind === "annotation" ? "annotations" : "replies";
+  await db
+    .prepare(
+      `UPDATE ${table} SET github_node_id = ?, github_url = ?, github_mirror_state = 'synced'
+      WHERE id = ?`
+    )
+    .bind(github.id, github.url, resource.id)
+    .run();
+}
+
+export async function markResourceMirrorFailed(
+  db: D1Database,
+  resource: D1Resource
+): Promise<void> {
+  const table = resource.kind === "annotation" ? "annotations" : "replies";
+  await db
+    .prepare(`UPDATE ${table} SET github_mirror_state = 'failed' WHERE id = ?`)
+    .bind(resource.id)
+    .run();
+}
+
+export function annotationMetadata(resource: D1Resource) {
+  if (resource.kind !== "annotation" || !resource.anchor) return null;
+  return parseAnnotationMetadata(resource.body) ?? {
+    version: 1 as const,
+    path: resource.articlePath,
+    anchor: resource.anchor,
+  };
 }

--- a/workers/comments-api/src/index.ts
+++ b/workers/comments-api/src/index.ts
@@ -12,13 +12,18 @@ import {
   type CommentReply,
 } from "../../../src/comments/protocol";
 import {
-  scheduleShadowWrite,
-  shadowCreateAnnotation,
-  shadowCreateReply,
-  shadowDeleteAnnotation,
-  shadowDeleteReply,
-  shadowUpdateAnnotation,
-  shadowUpdateReply,
+  annotationMetadata,
+  createD1Annotation,
+  createD1Reply,
+  deleteD1Resource,
+  getD1Article,
+  getD1CommentList,
+  getD1Resource,
+  markArticleMirrored,
+  markResourceMirrored,
+  markResourceMirrorFailed,
+  updateD1Resource,
+  type D1Resource,
 } from "./d1";
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
@@ -129,7 +134,7 @@ function allowedOrigins(env: Env): Set<string> {
 function corsHeaders(request: Request, env: Env): Headers {
   const headers = new Headers({
     "Access-Control-Allow-Headers":
-      "Authorization, Content-Type, X-CSRF-Token",
+      "Authorization, Content-Type, If-None-Match, X-CSRF-Token",
     "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
     "Access-Control-Max-Age": "86400",
     Vary: "Origin",
@@ -387,9 +392,9 @@ async function getCommentList(
   path: string
 ): Promise<CommentListResponse> {
   const discussion = await findDiscussion(env, path);
-  if (!discussion) return { discussion: null, threads: [], truncated: false };
+  if (!discussion) return { version: 0, discussion: null, threads: [], truncated: false };
   const { threads, truncated } = await loadComments(env, discussion, path);
-  return { discussion, threads, truncated };
+  return { version: 0, discussion, threads, truncated };
 }
 
 async function createDiscussion(
@@ -753,48 +758,119 @@ async function handleOAuthCallback(request: Request, env: Env): Promise<Response
   });
 }
 
-function cacheRequest(request: Request, path: string): Request {
-  const url = new URL(request.url);
-  url.pathname = "/__cache/comments";
-  url.search = new URLSearchParams({ path }).toString();
-  return new Request(url.toString(), { method: "GET" });
+function commentsEtag(version: number): string {
+  return `"comments-${version}"`;
 }
 
-async function invalidateCommentCache(request: Request, path: string): Promise<void> {
-  await caches.default.delete(cacheRequest(request, path));
+function logD1Metric(details: Record<string, string | number | boolean>): void {
+  console.log(JSON.stringify({ message: "comments_d1_metric", ...details }));
+}
+
+export function scheduleGitHubMirror(
+  ctx: ExecutionContext,
+  env: Env,
+  resource: D1Resource,
+  operation: () => Promise<void>
+): void {
+  ctx.waitUntil(
+    operation().catch(async error => {
+      await markResourceMirrorFailed(env.ANNOTATIONS_DB, resource).catch(markError => {
+        console.error(
+          JSON.stringify({
+            message: "github_mirror_state_update_failed",
+            operation: resource.kind,
+            resourceId: resource.id,
+            articlePath: resource.articlePath,
+            error: markError instanceof Error ? markError.message : String(markError),
+          })
+        );
+      });
+      console.error(
+        JSON.stringify({
+          message: "github_mirror_failed",
+          operation: resource.kind,
+          resourceId: resource.id,
+          articlePath: resource.articlePath,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      );
+    })
+  );
+}
+
+async function ensureGitHubDiscussion(
+  env: Env,
+  path: string,
+  title: string
+): Promise<DiscussionSummary> {
+  const article = await getD1Article(env.ANNOTATIONS_DB, path);
+  if (article && !article.github_discussion_id.startsWith("pending:")) {
+    return {
+      id: article.github_discussion_id,
+      number: article.github_discussion_number,
+      title: article.title,
+      url: article.github_url,
+    };
+  }
+  const discussion = (await findDiscussion(env, path)) ?? (await createDiscussion(env, path, title));
+  await markArticleMirrored(env.ANNOTATIONS_DB, path, discussion);
+  return discussion;
+}
+
+async function mirrorCreatedResource(
+  env: Env,
+  resource: D1Resource,
+  articleTitle: string
+): Promise<void> {
+  const discussion = await ensureGitHubDiscussion(env, resource.articlePath, articleTitle);
+  let replyToId: string | undefined;
+  if (resource.kind === "reply") {
+    const parent = await getD1Resource(
+      env.ANNOTATIONS_DB,
+      resource.annotationId,
+      env.OWNER_LOGIN
+    );
+    if (!parent?.githubNodeId) throw new Error("github_parent_not_mirrored");
+    replyToId = parent.githubNodeId;
+  }
+  const comment = await addDiscussionComment(
+    env,
+    discussion.id,
+    resource.body,
+    replyToId
+  );
+  await markResourceMirrored(env.ANNOTATIONS_DB, resource, comment);
 }
 
 async function handleGetComments(
   request: Request,
-  env: Env,
-  ctx: ExecutionContext
+  env: Env
 ): Promise<Response> {
   const url = new URL(request.url);
   const path = normalizeArticlePath(url.searchParams.get("path") ?? "");
   if (!path) throw new HttpError(400, "Article path is invalid", "invalid_path");
 
-  const key = cacheRequest(request, path);
-  const cached = await caches.default.match(key);
-  if (cached) {
-    const response = new Response(cached.body, cached);
-    response.headers.delete("Access-Control-Allow-Origin");
-    for (const [name, value] of corsHeaders(request, env)) response.headers.set(name, value);
-    response.headers.set("X-Comments-Cache", "HIT");
-    return response;
+  const startedAt = performance.now();
+  const value = await getD1CommentList(env.ANNOTATIONS_DB, path);
+  const durationMs = Math.round((performance.now() - startedAt) * 10) / 10;
+  const etag = commentsEtag(value.version);
+  logD1Metric({
+    route: "/api/comments",
+    operation: "read",
+    status: 200,
+    d1DurationMs: durationMs,
+    threadCount: value.threads.length,
+    articleVersion: value.version,
+  });
+  if (request.headers.get("If-None-Match") === etag) {
+    return new Response(null, {
+      status: 304,
+      headers: { ...Object.fromEntries(corsHeaders(request, env)), ETag: etag },
+    });
   }
-
-  const value = await getCommentList(env, path);
   const response = jsonResponse(request, env, value, {
-    headers: { "Cache-Control": "public, max-age=30, stale-while-revalidate=60" },
+    headers: { "Cache-Control": "no-cache", ETag: etag },
   });
-  const cachedResponse = Response.json(value, {
-    headers: {
-      "Cache-Control": "public, max-age=30, stale-while-revalidate=60",
-      "Content-Type": "application/json; charset=utf-8",
-    },
-  });
-  ctx.waitUntil(caches.default.put(key, cachedResponse));
-  response.headers.set("X-Comments-Cache", "MISS");
   return response;
 }
 
@@ -810,77 +886,59 @@ async function handleCreateComment(
     throw new HttpError(400, "Comment input is invalid", "invalid_comment");
   }
 
-  let discussion = await findDiscussion(env, input.data.path);
-  if (!discussion) {
-    discussion = await createDiscussion(env, input.data.path, input.data.articleTitle);
-  }
-
-  let commentBody = input.data.body;
+  const author = {
+    login: env.OWNER_LOGIN,
+    avatarUrl: `https://github.com/${env.OWNER_LOGIN}.png`,
+    url: `https://github.com/${env.OWNER_LOGIN}`,
+  };
+  const startedAt = performance.now();
+  let result;
   if (input.data.replyToId) {
-    const parent = await getCommentResource(env, input.data.replyToId);
-    if (parent?.discussion.id !== discussion.id) {
-      throw new HttpError(400, "Reply target is invalid", "invalid_reply");
+    try {
+      result = await createD1Reply(env.ANNOTATIONS_DB, {
+        path: input.data.path,
+        annotationId: input.data.replyToId,
+        body: input.data.body,
+        author,
+        siteUrl: env.SITE_URL,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === "annotation_not_found") {
+        throw new HttpError(404, "Reply target was not found", "comment_not_found");
+      }
+      throw error;
     }
   } else {
     if (!input.data.anchor) {
       throw new HttpError(400, "Annotation anchor is required", "anchor_required");
     }
-    commentBody = buildAnnotationCommentBody(
+    const storedBody = buildAnnotationCommentBody(
       { version: 1, path: input.data.path, anchor: input.data.anchor },
       input.data.body
     );
+    result = await createD1Annotation(env.ANNOTATIONS_DB, {
+      path: input.data.path,
+      articleTitle: input.data.articleTitle,
+      body: storedBody,
+      anchor: input.data.anchor,
+      author,
+      siteUrl: env.SITE_URL,
+    });
   }
-
-  const comment = await addDiscussionComment(
-    env,
-    discussion.id,
-    commentBody,
-    input.data.replyToId
+  const id = "thread" in result ? result.thread.id : result.reply.id;
+  const resource = await getD1Resource(env.ANNOTATIONS_DB, id, env.OWNER_LOGIN);
+  if (!resource) throw new Error("created_resource_not_found");
+  scheduleGitHubMirror(ctx, env, resource, () =>
+    mirrorCreatedResource(env, resource, input.data.articleTitle)
   );
-  await invalidateCommentCache(request, input.data.path);
-  const article = {
-    path: input.data.path,
-    title: input.data.articleTitle,
-    discussion,
-  };
-  if (input.data.replyToId) {
-    scheduleShadowWrite(
-      ctx,
-      {
-        operation: "create_reply",
-        resourceId: comment.id,
-        articlePath: input.data.path,
-      },
-      () =>
-        shadowCreateReply(env.ANNOTATIONS_DB, {
-          article,
-          comment,
-          annotationId: input.data.replyToId!,
-          body: input.data.body,
-        })
-    );
-  } else {
-    scheduleShadowWrite(
-      ctx,
-      {
-        operation: "create_annotation",
-        resourceId: comment.id,
-        articlePath: input.data.path,
-      },
-      () =>
-        shadowCreateAnnotation(env.ANNOTATIONS_DB, {
-          article,
-          comment,
-          body: comment.body,
-          metadata: {
-            version: 1,
-            path: input.data.path,
-            anchor: input.data.anchor!,
-          },
-        })
-    );
-  }
-  return jsonResponse(request, env, { comment }, { status: 201 });
+  logD1Metric({
+    route: "/api/owner/comments",
+    operation: resource.kind === "annotation" ? "create_annotation" : "create_reply",
+    status: 201,
+    d1DurationMs: Math.round((performance.now() - startedAt) * 10) / 10,
+    articleVersion: result.version,
+  });
+  return jsonResponse(request, env, result, { status: 201 });
 }
 
 async function handleUpdateComment(
@@ -895,41 +953,33 @@ async function handleUpdateComment(
   if (!input.success) {
     throw new HttpError(400, "Comment input is invalid", "invalid_comment");
   }
-  const resource = await getCommentResource(env, id);
+  const resource = await getD1Resource(env.ANNOTATIONS_DB, id, env.OWNER_LOGIN);
   if (!resource) throw new HttpError(404, "Comment was not found", "comment_not_found");
-  const metadata = parseAnnotationMetadata(resource.body);
+  const metadata = annotationMetadata(resource);
   const body = metadata
     ? buildAnnotationCommentBody(metadata, input.data.body)
     : input.data.body;
-  const comment = await updateDiscussionComment(env, id, body);
-  const path = normalizeArticlePath(resource.discussion.title);
-  if (path) await invalidateCommentCache(request, path);
-  if (path) {
-    const article = {
-      path,
-      title: resource.discussion.title,
-      discussion: resource.discussion,
-    };
-    const operation = metadata ? "update_annotation" : "update_reply";
-    scheduleShadowWrite(
-      ctx,
-      { operation, resourceId: comment.id, articlePath: path },
-      () =>
-        metadata
-          ? shadowUpdateAnnotation(env.ANNOTATIONS_DB, {
-              article,
-              comment,
-              body: comment.body,
-              metadata,
-            })
-          : shadowUpdateReply(env.ANNOTATIONS_DB, {
-              article,
-              comment,
-              body: input.data.body,
-            })
-    );
+  const startedAt = performance.now();
+  const result = await updateD1Resource(
+    env.ANNOTATIONS_DB,
+    resource,
+    body,
+    env.OWNER_LOGIN
+  );
+  if (resource.githubNodeId) {
+    scheduleGitHubMirror(ctx, env, resource, async () => {
+      const comment = await updateDiscussionComment(env, resource.githubNodeId!, body);
+      await markResourceMirrored(env.ANNOTATIONS_DB, resource, comment);
+    });
   }
-  return jsonResponse(request, env, { comment });
+  logD1Metric({
+    route: "/api/owner/comments/:id",
+    operation: `update_${resource.kind}`,
+    status: 200,
+    d1DurationMs: Math.round((performance.now() - startedAt) * 10) / 10,
+    articleVersion: result.version,
+  });
+  return jsonResponse(request, env, { version: result.version });
 }
 
 async function handleDeleteComment(
@@ -940,40 +990,23 @@ async function handleDeleteComment(
 ): Promise<Response> {
   requireAllowedOrigin(request, env);
   await requireOwnerSession(request, env, true);
-  const resource = await getCommentResource(env, id);
-  await deleteDiscussionComment(env, id);
-  const path = normalizeArticlePath(resource?.discussion.title ?? "");
-  if (path) await invalidateCommentCache(request, path);
-  if (path && resource) {
-    const metadata = parseAnnotationMetadata(resource.body);
-    const deletedAt = new Date().toISOString();
-    const article = {
-      path,
-      title: resource.discussion.title,
-      discussion: resource.discussion,
-    };
-    scheduleShadowWrite(
-      ctx,
-      {
-        operation: metadata ? "delete_annotation" : "delete_reply",
-        resourceId: id,
-        articlePath: path,
-      },
-      () =>
-        metadata
-          ? shadowDeleteAnnotation(env.ANNOTATIONS_DB, {
-              article,
-              resourceId: id,
-              deletedAt,
-            })
-          : shadowDeleteReply(env.ANNOTATIONS_DB, {
-              article,
-              resourceId: id,
-              deletedAt,
-            })
+  const resource = await getD1Resource(env.ANNOTATIONS_DB, id, env.OWNER_LOGIN);
+  if (!resource) throw new HttpError(404, "Comment was not found", "comment_not_found");
+  const startedAt = performance.now();
+  const result = await deleteD1Resource(env.ANNOTATIONS_DB, resource);
+  if (resource.githubNodeId) {
+    scheduleGitHubMirror(ctx, env, resource, () =>
+      deleteDiscussionComment(env, resource.githubNodeId!)
     );
   }
-  return new Response(null, { status: 204, headers: corsHeaders(request, env) });
+  logD1Metric({
+    route: "/api/owner/comments/:id",
+    operation: `delete_${resource.kind}`,
+    status: 200,
+    d1DurationMs: Math.round((performance.now() - startedAt) * 10) / 10,
+    articleVersion: result.version,
+  });
+  return jsonResponse(request, env, result);
 }
 
 async function routeRequest(
@@ -995,7 +1028,7 @@ async function routeRequest(
     return handleOAuthCallback(request, env);
   }
   if (request.method === "GET" && url.pathname === "/api/comments") {
-    return handleGetComments(request, env, ctx);
+    return handleGetComments(request, env);
   }
   if (request.method === "GET" && url.pathname === "/api/owner/session") {
     try {

--- a/workers/comments-api/test/d1.test.ts
+++ b/workers/comments-api/test/d1.test.ts
@@ -1,207 +1,168 @@
-import { describe, expect, it, vi } from "vitest";
-import type { AnnotationMetadata } from "../../../src/comments/protocol";
+import { describe, expect, it } from "vitest";
 import {
-  scheduleShadowWrite,
-  shadowCreateAnnotation,
-  shadowCreateReply,
-  shadowDeleteAnnotation,
-  shadowDeleteReply,
-  shadowUpdateAnnotation,
-  shadowUpdateReply,
+  createD1Annotation,
+  createD1Reply,
+  deleteD1Resource,
+  getD1CommentList,
+  updateD1Resource,
+  type D1Resource,
 } from "../src/d1";
 
-type CapturedStatement = {
-  sql: string;
-  params: unknown[];
-};
+type CapturedStatement = { sql: string; params: unknown[] };
 
-function createDatabase(changes = 1): {
-  db: D1Database;
-  statements: CapturedStatement[];
-  batches: CapturedStatement[][];
-} {
+function createDatabase(options: {
+  first?: (sql: string, params: unknown[]) => unknown;
+  all?: (sql: string, params: unknown[]) => unknown[];
+  changes?: number;
+} = {}) {
   const statements: CapturedStatement[] = [];
   const batches: CapturedStatement[][] = [];
-  const db = {
-    prepare(sql: string) {
-      const statement: CapturedStatement = { sql, params: [] };
+  const prepare = (sql: string) => ({
+    bind(...params: unknown[]) {
+      const captured = { sql, params };
+      statements.push(captured);
       return {
-        bind(...params: unknown[]) {
-          statement.params = params;
-          statements.push(statement);
-          return {
-            ...this,
-            run: vi.fn().mockResolvedValue({ meta: { changes } }),
-          };
-        },
+        sql,
+        params,
+        first: async () => options.first?.(sql, params) ?? null,
+        all: async () => ({ results: options.all?.(sql, params) ?? [] }),
+        run: async () => ({ meta: { changes: options.changes ?? 1 } }),
       };
     },
-    batch(batch: Array<{ sql?: string; params?: unknown[] }>) {
-      batches.push(
-        batch.map(statement => ({
-          sql: statement.sql ?? "",
-          params: statement.params ?? [],
-        }))
-      );
-      return Promise.resolve(batch.map(() => ({ meta: { changes } })));
+  });
+  const db = {
+    prepare,
+    async batch(items: Array<{ sql?: string; params?: unknown[] }>) {
+      batches.push(items.map(item => ({ sql: item.sql ?? "", params: item.params ?? [] })));
+      return items.map(() => ({ meta: { changes: options.changes ?? 1 } }));
     },
-  };
-  return { db: db as never, statements, batches };
+  } as unknown as D1Database;
+  return { db, statements, batches };
 }
 
-const metadata: AnnotationMetadata = {
-  version: 1,
-  path: "/posts/example/",
-  anchor: {
-    blockId: "cb-article-example",
-    headingId: "example",
-    exact: "selected text",
-    prefix: "before",
-    suffix: "after",
-    view: "article",
-  },
+const path = "/posts/example/";
+const anchor = {
+  blockId: "cb-article-example",
+  headingId: "example",
+  exact: "selected text",
+  prefix: "before",
+  suffix: "after",
+  view: "article" as const,
+};
+const author = {
+  login: "llccing",
+  avatarUrl: "https://github.com/llccing.png",
+  url: "https://github.com/llccing",
+};
+const annotation: D1Resource = {
+  kind: "annotation",
+  id: "annotation-1",
+  articlePath: path,
+  annotationId: "annotation-1",
+  body: "before",
+  githubNodeId: "DC_1",
+  githubMirrorState: "synced",
+  anchor,
 };
 
-const article = {
-  path: metadata.path,
-  title: "Example",
-  discussion: {
-    id: "D_1",
-    number: 1,
-    url: "https://github.com/discussions/1",
-  },
-};
-
-const comment = {
-  id: "DC_1",
-  body: "GitHub body",
-  url: "https://github.com/discussions/1#discussioncomment-1",
-  createdAt: "2026-08-04T00:00:00.000Z",
-  updatedAt: "2026-08-04T00:00:01.000Z",
-  author: {
-    login: "llccing",
-    avatarUrl: "https://github.com/avatar.png",
-    url: "https://github.com/llccing",
-  },
-};
-
-describe("D1 annotation shadow writes", () => {
-  it("maps annotation and reply creates into parameterized batches", async () => {
-    const { db, statements, batches } = createDatabase();
-
-    await shadowCreateAnnotation(db, {
-      article,
-      comment,
-      body: "annotation body",
-      metadata,
+describe("D1 primary annotation storage", () => {
+  it("maps public rows and excludes deleted content in SQL", async () => {
+    const { db, statements } = createDatabase({
+      first: sql =>
+        sql.includes("FROM articles")
+          ? {
+              path,
+              title: "Example",
+              github_discussion_id: "D_1",
+              github_discussion_number: 1,
+              github_url: "https://github.com/discussions/1",
+              version: 7,
+            }
+          : null,
+      all: sql =>
+        sql.includes("FROM annotations")
+          ? [
+              {
+                id: "annotation-1",
+                article_path: path,
+                author_login: author.login,
+                author_avatar_url: author.avatarUrl,
+                author_url: author.url,
+                body: "body",
+                github_url: "https://github.com/comment/1",
+                block_id: anchor.blockId,
+                heading_id: anchor.headingId,
+                exact_text: anchor.exact,
+                prefix_text: anchor.prefix,
+                suffix_text: anchor.suffix,
+                view: anchor.view,
+                github_node_id: "DC_1",
+                github_mirror_state: "synced",
+                created_at: "2026-08-04T00:00:00Z",
+                updated_at: "2026-08-04T00:00:00Z",
+              },
+            ]
+          : [],
     });
-    await shadowCreateReply(db, {
-      article,
-      comment: { ...comment, id: "DC_REPLY" },
-      annotationId: comment.id,
-      body: "reply body",
-    });
-
-    expect(batches).toHaveLength(2);
-    expect(statements.some(item => item.sql.includes("INSERT INTO annotations"))).toBe(
-      true
-    );
-    expect(statements.some(item => item.sql.includes("INSERT INTO replies"))).toBe(
-      true
-    );
+    const result = await getD1CommentList(db, path);
+    expect(result.version).toBe(7);
+    expect(result.threads.map(thread => thread.id)).toEqual(["annotation-1"]);
     expect(
-      statements.find(item => item.sql.includes("INSERT INTO annotations"))?.params
-    ).toContain("annotation body");
+      statements.filter(item => item.sql.includes("FROM annotations"))[0].sql
+    ).toContain("deleted_at IS NULL");
     expect(
-      statements.find(item => item.sql.includes("INSERT INTO replies"))?.params
-    ).toContain(comment.id);
-    expect(statements.every(item => !item.sql.includes("annotation body"))).toBe(true);
+      statements.filter(item => item.sql.includes("FROM annotations"))[0].sql
+    ).toContain("status = 'open'");
   });
 
-  it("maps annotation and reply updates to their respective tables", async () => {
-    const { db, statements } = createDatabase();
-
-    await shadowUpdateAnnotation(db, {
-      article,
-      comment,
-      body: "updated annotation",
-      metadata,
-    });
-    await shadowUpdateReply(db, {
-      article,
-      comment: { ...comment, id: "DC_REPLY" },
-      body: "updated reply",
-    });
-
-    expect(statements.some(item => item.sql.includes("INSERT INTO annotations"))).toBe(
-      true
-    );
-    expect(statements.some(item => item.sql.includes("UPDATE replies SET"))).toBe(
-      true
-    );
-  });
-
-  it("soft-deletes annotations with replies and deletes individual replies", async () => {
-    const { db, statements } = createDatabase();
-    const deletedAt = "2026-08-04T00:01:00.000Z";
-
-    await shadowDeleteAnnotation(db, {
-      article,
-      resourceId: comment.id,
-      deletedAt,
-    });
-    await shadowDeleteReply(db, {
-      article,
-      resourceId: "DC_REPLY",
-      deletedAt,
-    });
-
-    expect(
-      statements.some(item =>
-        item.sql.includes("status = 'deleted', deleted_at = ?")
-      )
-    ).toBe(true);
-    expect(
-      statements.some(item => item.sql.includes("WHERE annotation_id = ?"))
-    ).toBe(true);
-    expect(
-      statements.some(item => item.sql.includes("WHERE id = ? AND deleted_at IS NULL"))
-    ).toBe(true);
-  });
-
-  it("reports a missing reply instead of silently accepting shadow drift", async () => {
-    const { db } = createDatabase(0);
-    await expect(
-      shadowUpdateReply(db, {
-        article,
-        comment: { ...comment, id: "missing" },
-        body: "updated reply",
-      })
-    ).rejects.toThrow("was not found for update");
-  });
-
-  it("contains D1 failures inside waitUntil and logs structured context", async () => {
-    const waitUntil = vi.fn();
-    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
-    scheduleShadowWrite(
-      { waitUntil } as never,
-      {
-        operation: "create_annotation",
-        resourceId: comment.id,
-        articlePath: article.path,
+  it("creates annotations and replies with pending GitHub mirrors and increments version", async () => {
+    const { db, statements, batches } = createDatabase({
+      first: sql => {
+        if (sql.includes("SELECT version")) return { version: 2 };
+        if (sql.includes("SELECT id FROM annotations")) return { id: "annotation-1" };
+        return null;
       },
-      () => Promise.reject(new Error("D1 unavailable"))
-    );
-
-    expect(waitUntil).toHaveBeenCalledOnce();
-    await expect(waitUntil.mock.calls[0][0]).resolves.toBeUndefined();
-    expect(JSON.parse(error.mock.calls[0][0] as string)).toMatchObject({
-      message: "d1_shadow_write_failed",
-      operation: "create_annotation",
-      resourceId: comment.id,
-      articlePath: article.path,
-      error: "D1 unavailable",
     });
+    await createD1Annotation(db, {
+      path,
+      articleTitle: "Example",
+      body: "annotation body",
+      anchor,
+      author,
+      siteUrl: "https://rowanliu.com",
+    });
+    await createD1Reply(db, {
+      path,
+      annotationId: "annotation-1",
+      body: "reply body",
+      author,
+      siteUrl: "https://rowanliu.com",
+    });
+    expect(batches).toHaveLength(2);
+    expect(statements.some(item => item.sql.includes("INSERT INTO annotations"))).toBe(true);
+    expect(statements.some(item => item.sql.includes("INSERT INTO replies"))).toBe(true);
+    expect(statements.filter(item => item.sql.includes("INSERT INTO annotations"))[0].sql).toContain(
+      "'pending'"
+    );
+  });
+
+  it("records a revision before an edit and increments the article version", async () => {
+    const { db, statements, batches } = createDatabase({
+      first: sql => (sql.includes("SELECT version") ? { version: 8 } : null),
+    });
+    const result = await updateD1Resource(db, annotation, "after", author.login);
+    expect(result.version).toBe(8);
+    expect(batches[0][0].sql).toContain("INSERT INTO annotation_revisions");
+    expect(batches[0][0].params).toContain("before");
+    expect(statements.some(item => item.sql.includes("version = version + 1"))).toBe(true);
+  });
+
+  it("soft-deletes annotations and their replies", async () => {
+    const { db, statements } = createDatabase({
+      first: sql => (sql.includes("SELECT version") ? { version: 9 } : null),
+    });
+    await deleteD1Resource(db, annotation);
+    expect(statements.some(item => item.sql.includes("status = 'deleted'"))).toBe(true);
+    expect(statements.some(item => item.sql.includes("WHERE annotation_id = ?"))).toBe(true);
   });
 });

--- a/workers/comments-api/test/index.test.ts
+++ b/workers/comments-api/test/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildAnnotationCommentBody, type AnnotationMetadata } from "../../../src/comments/protocol";
-import worker from "../src/index";
+import worker, { scheduleGitHubMirror } from "../src/index";
 
 const articlePath = "/posts/example/";
 const discussionTitle = "posts/example/";
@@ -17,6 +17,70 @@ const metadata: AnnotationMetadata = {
   },
 };
 
+function readDatabase() {
+  const annotation = {
+    id: "annotation",
+    article_path: articlePath,
+    author_login: "llccing",
+    author_avatar_url: "https://github.com/llccing.png",
+    author_url: "https://github.com/llccing",
+    body: buildAnnotationCommentBody(metadata, "这是一条批注"),
+    github_url: "https://github.com/annotation",
+    block_id: metadata.anchor.blockId,
+    heading_id: metadata.anchor.headingId,
+    exact_text: metadata.anchor.exact,
+    prefix_text: metadata.anchor.prefix,
+    suffix_text: metadata.anchor.suffix,
+    view: metadata.anchor.view,
+    github_node_id: "DC_1",
+    github_mirror_state: "synced",
+    created_at: "2026-08-02T00:00:00Z",
+    updated_at: "2026-08-02T00:00:00Z",
+  };
+  const reply = {
+    id: "ai-reply",
+    annotation_id: annotation.id,
+    article_path: articlePath,
+    author_login: "github-actions",
+    author_avatar_url: "",
+    author_url: "",
+    body: "<!-- rowan-ai-reply:v1 annotation -->\n\nAI 回答",
+    github_url: "https://github.com/reply",
+    github_node_id: "DC_2",
+    github_mirror_state: "synced",
+    created_at: "2026-08-02T00:01:00Z",
+    updated_at: "2026-08-02T00:01:00Z",
+  };
+  return {
+    prepare(sql: string) {
+      return {
+        bind() {
+          return {
+            first: async () =>
+              sql.includes("FROM articles")
+                ? {
+                    path: articlePath,
+                    title: discussionTitle,
+                    github_discussion_id: "D_1",
+                    github_discussion_number: 1,
+                    github_url: "https://github.com/discussion/1",
+                    version: 4,
+                  }
+                : null,
+            all: async () => ({
+              results: sql.includes("FROM annotations")
+                ? [annotation]
+                : sql.includes("FROM replies")
+                  ? [reply]
+                  : [],
+            }),
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
 const env = {
   GITHUB_OWNER: "llccing",
   GITHUB_REPO: "llccing.github.io",
@@ -29,6 +93,7 @@ const env = {
   GITHUB_OAUTH_CLIENT_ID: "test-client-id",
   GITHUB_OAUTH_CLIENT_SECRET: "test-client-secret",
   SESSION_SECRET: "test-session-secret-that-is-long-enough",
+  ANNOTATIONS_DB: readDatabase(),
 };
 
 const ctx = {
@@ -81,86 +146,8 @@ describe("comments Worker", () => {
     await expect(response.json()).resolves.toEqual({ canWrite: false });
   });
 
-  it("returns only metadata-backed inline annotations", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        githubResponse({
-          repository: {
-            discussions: {
-              nodes: [
-                { id: "D_1", number: 1, title: discussionTitle, url: "https://github.com/discussion/1" },
-              ],
-              pageInfo: { hasNextPage: false, endCursor: null },
-            },
-          },
-        })
-      )
-      .mockResolvedValueOnce(
-        githubResponse({
-          node: {
-            id: "D_1",
-            number: 1,
-            title: discussionTitle,
-            url: "https://github.com/discussion/1",
-            comments: {
-              nodes: [
-                {
-                  id: "legacy",
-                  url: "https://github.com/legacy",
-                  body: "原有 Giscus 评论",
-                  bodyHTML: "<p>原有 Giscus 评论</p>",
-                  createdAt: "2026-08-01T00:00:00Z",
-                  updatedAt: "2026-08-01T00:00:00Z",
-                  author: { login: "llccing", avatarUrl: "", url: "" },
-                  replies: { nodes: [], pageInfo: { hasNextPage: false } },
-                },
-                {
-                  id: "forged-annotation",
-                  url: "https://github.com/forged",
-                  body: buildAnnotationCommentBody(metadata, "伪造的批注"),
-                  bodyHTML: "<p>伪造的批注</p>",
-                  createdAt: "2026-08-02T00:00:00Z",
-                  updatedAt: "2026-08-02T00:00:00Z",
-                  author: { login: "someone-else", avatarUrl: "", url: "" },
-                  replies: { nodes: [], pageInfo: { hasNextPage: false } },
-                },
-                {
-                  id: "annotation",
-                  url: "https://github.com/annotation",
-                  body: buildAnnotationCommentBody(metadata, "这是一条批注"),
-                  bodyHTML: "<blockquote>被批注的句子</blockquote><p>这是一条批注</p>",
-                  createdAt: "2026-08-02T00:00:00Z",
-                  updatedAt: "2026-08-02T00:00:00Z",
-                  author: { login: "llccing", avatarUrl: "", url: "" },
-                  replies: {
-                    nodes: [
-                      {
-                        id: "ai-reply",
-                        body: "<!-- rowan-ai-reply:v1 annotation -->\n\nAI 回答",
-                        bodyHTML: "<p>AI 回答</p>",
-                        createdAt: "2026-08-02T00:01:00Z",
-                        updatedAt: "2026-08-02T00:01:00Z",
-                        author: { login: "github-actions", avatarUrl: "", url: "" },
-                      },
-                      {
-                        id: "untrusted-reply",
-                        body: "伪造回复",
-                        bodyHTML: "<p>伪造回复</p>",
-                        createdAt: "2026-08-02T00:02:00Z",
-                        updatedAt: "2026-08-02T00:02:00Z",
-                        author: { login: "someone-else", avatarUrl: "", url: "" },
-                      },
-                    ],
-                    pageInfo: { hasNextPage: false },
-                  },
-                },
-              ],
-              pageInfo: { hasNextPage: false, endCursor: null },
-            },
-          },
-        })
-      );
+  it("returns D1 annotations without calling GitHub and supports conditional reads", async () => {
+    const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
     const response = await worker.fetch(
@@ -177,8 +164,56 @@ describe("comments Worker", () => {
     expect(response.status).toBe(200);
     expect(payload.threads.map(thread => thread.id)).toEqual(["annotation"]);
     expect(payload.threads[0].replies.map(reply => reply.id)).toEqual(["ai-reply"]);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(payload.threads[0].replies.map(reply => reply.id)).toEqual(["ai-reply"]);
+    expect(response.headers.get("ETag")).toBe('"comments-4"');
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("https://rowanliu.com");
+
+    const unchanged = await worker.fetch(
+      new Request(
+        `https://comments.example/api/comments?path=${encodeURIComponent(articlePath)}`,
+        { headers: { "If-None-Match": '"comments-4"' } }
+      ),
+      env as never,
+      ctx as never
+    );
+    expect(unchanged.status).toBe(304);
+  });
+
+  it("contains an asynchronous GitHub mirror failure after D1 success", async () => {
+    const waitUntil = vi.fn();
+    const run = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+    const mirrorEnv = {
+      ...env,
+      ANNOTATIONS_DB: {
+        prepare: () => ({ bind: () => ({ run }) }),
+      } as unknown as D1Database,
+    };
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    scheduleGitHubMirror(
+      { ...ctx, waitUntil } as never,
+      mirrorEnv as never,
+      {
+        kind: "annotation",
+        id: "d1-id",
+        articlePath,
+        annotationId: "d1-id",
+        body: "body",
+        githubNodeId: null,
+        githubMirrorState: "pending",
+        anchor: metadata.anchor,
+      },
+      () => Promise.reject(new Error("GitHub unavailable"))
+    );
+    expect(waitUntil).toHaveBeenCalledOnce();
+    await expect(waitUntil.mock.calls[0][0]).resolves.toBeUndefined();
+    expect(run).toHaveBeenCalledOnce();
+    expect(JSON.parse(error.mock.calls.at(-1)?.[0] as string)).toMatchObject({
+      message: "github_mirror_failed",
+      resourceId: "d1-id",
+      articlePath,
+      error: "GitHub unavailable",
+    });
   });
 
   it("rejects owner mutations from an unapproved origin before GitHub access", async () => {


### PR DESCRIPTION
## Summary

- make D1 authoritative for annotation reads and writes
- return versioned ETag responses and mirror GitHub asynchronously
- add optimistic create, reply, edit, delete, rollback, and retry UI
- add the Phase 5 migration, tests, report, and updated handoff

## Validation

- pnpm lint
- pnpm test (7 files, 34 tests)
- pnpm check:worker
- pnpm build
- local and remote D1 migration verification (1 article, 3 annotations, 2 replies, no FK violations)
- production D1 read and conditional 304 verification

## Boundaries

Queues, Durable Objects, WebSockets, DNS, Giscus, GitHub Discussions, GitHub Pages rollback, and annotation-ai.yml are unchanged.