### PR TITLE
fix(comments): keep polling active AI jobs

### DIFF
--- a/src/comments/polling.test.ts
+++ b/src/comments/polling.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startSequentialPolling } from "./polling";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("startSequentialPolling", () => {
+  it("continues polling when a request completes without changing state", async () => {
+    vi.useFakeTimers();
+    const poll = vi.fn().mockResolvedValue(undefined);
+    const stop = startSequentialPolling(poll, 1500);
+
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(poll).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(poll).toHaveBeenCalledTimes(2);
+
+    stop();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(poll).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for the current request before scheduling the next one", async () => {
+    vi.useFakeTimers();
+    let finishPoll: (() => void) | undefined;
+    const poll = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          finishPoll = resolve;
+        })
+    );
+    const stop = startSequentialPolling(poll, 1500);
+
+    await vi.advanceTimersByTimeAsync(4500);
+    expect(poll).toHaveBeenCalledTimes(1);
+
+    finishPoll?.();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(poll).toHaveBeenCalledTimes(2);
+
+    stop();
+  });
+});

--- a/src/comments/polling.ts
+++ b/src/comments/polling.ts
@@ -1,0 +1,23 @@
+export function startSequentialPolling(
+  poll: () => Promise<void>,
+  delayMs: number
+): () => void {
+  let cancelled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const schedule = () => {
+    timer = setTimeout(async () => {
+      try {
+        await poll();
+      } finally {
+        if (!cancelled) schedule();
+      }
+    }, delayMs);
+  };
+
+  schedule();
+  return () => {
+    cancelled = true;
+    if (timer !== undefined) clearTimeout(timer);
+  };
+}

--- a/src/components/InlineComments.tsx
+++ b/src/components/InlineComments.tsx
@@ -31,6 +31,7 @@ import {
   replaceOptimisticThread,
   updateOptimisticBody,
 } from "../comments/optimistic";
+import { startSequentialPolling } from "../comments/polling";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const ANNOTATION_MODE_KEY = "rowan-comments-annotation-mode";
@@ -295,9 +296,8 @@ export default function InlineComments({
 
   useEffect(() => {
     if (!hasActiveAiJob) return;
-    const timer = window.setTimeout(() => void reload(), 1500);
-    return () => window.clearTimeout(timer);
-  }, [hasActiveAiJob, reload, threads]);
+    return startSequentialPolling(reload, 1500);
+  }, [hasActiveAiJob, reload]);
 
   useEffect(() => {
     fetch(`${endpoint}/api/owner/session`, {


### PR DESCRIPTION
## Summary
- continue polling active AI jobs after an unchanged 304 response
- wait for each poll to finish before scheduling the next request
- add regression coverage for unchanged responses and overlapping requests

## Verification
- pnpm test (38 tests)
- pnpm lint
- pnpm build
- Playwright: 200 queued -> 304 unchanged -> 200 completed; UI showed AI 已回答 without reload